### PR TITLE
AWS-211 implement get classic libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "2.7"
 install:
   - pip install -r requirements.txt
+addons:
+  postgresql: "9.3"
 script: nosetests --with-coverage classic/tests/unit_tests
 sudo: false
 after_success:

--- a/classic/app.py
+++ b/classic/app.py
@@ -8,7 +8,8 @@ from flask import Flask
 from flask.ext.restful import Api
 from flask.ext.discoverer import Discoverer
 from flask.ext.consulate import Consul, ConsulConnectionError
-from views import AuthenticateUser
+from views import AuthenticateUser, ClassicLibraries
+from models import db
 
 
 def create_app():
@@ -30,11 +31,11 @@ def create_app():
     # Register extensions
     api = Api(app)
     Discoverer(app)
+    db.init_app(app)
 
     # Add the end resource end points
-    api.add_resource(AuthenticateUser,
-                     '/auth',
-                     methods=['POST'])
+    api.add_resource(AuthenticateUser, '/auth', methods=['POST'])
+    api.add_resource(ClassicLibraries, '/libraries', methods=['GET'])
 
     return app
 

--- a/classic/config.py
+++ b/classic/config.py
@@ -1,10 +1,13 @@
 ADS_CLASSIC_URL = 'http://{mirror}/email={email}&password={password}'
+ADS_CLASSIC_LIBRARIES_URL = 'http://{mirror}/cookie={cookie}'
 ADS_CLASSIC_MIRROR_LIST = ['adstrio.cfa.harvard.edu', 'adsnun.cfa.harvard.edu', 'adsate.cfa.harvard.edu',
                            'astrobib.u-strasbg.fr', 'ads.nao.ac.jp', 'ads.astro.puc.cl', 'esoads.eso.org',
                            'ukads.nottingham.ac.uk', 'ads.iucaa.ernet.in', 'ads.inasan.ru', 'ads.bao.ac.cn',
                            'ads.mao.kiev.ua', 'ads.ari.uni-heidelberg.de', 'ads.arsip.lipi.go.id', 'ads.on.br',
                            'saaoads.chpc.ac.za', 'adsabs.harvard.edu']
 CLASSIC_MYADS_USER_DATA_URL = 'http://api.adsabs.harvard.edu/v1/vault/user-data'
+SQLALCHEMY_BINDS = {'imports': ''}
+SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 CLASSIC_LOGGING = {
     'version': 1,

--- a/classic/http_errors.py
+++ b/classic/http_errors.py
@@ -34,6 +34,11 @@ CLASSIC_TIMEOUT = dict(
     code=504
 )
 
+NO_CLASSIC_ACCOUNT = dict(
+    message='This user has not setup an ADS Classic account',
+    code=400
+)
+
 MYADS_TIMEOUT = dict(
     message='ADSWS myADS end point timed out before it could respond (> 30s)',
     code=504

--- a/classic/models.py
+++ b/classic/models.py
@@ -1,0 +1,27 @@
+"""
+Models use to define the database
+The database is not initiated here, but a pointer is created named db. This is
+to be passed to the app creator within the Flask blueprint.
+"""
+
+from flask.ext.sqlalchemy import SQLAlchemy
+
+db = SQLAlchemy()
+
+
+class Users(db.Model):
+    """
+    Users table
+    Foreign-key absolute_uid is the primary key of the user in the user
+    database microservice.
+    """
+    __bind_key__ = 'imports'
+    __tablename__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    absolute_uid = db.Column(db.Integer, unique=True, nullable=False)
+    classic_mirror = db.Column(db.String(32), nullable=False)
+    classic_cookie = db.Column(db.String(32), nullable=False)
+
+    def __repr__(self):
+        return '<User: id {0}, absolute_uid {1}, classic_cookie "{2}">'\
+            .format(self.id, self.absolute_uid, self.classic_cookie)

--- a/classic/tests/unit_tests/stub_data.py
+++ b/classic/tests/unit_tests/stub_data.py
@@ -101,3 +101,38 @@ stub_classic_no_cookie = {
         "man_cmd": "4"
         }
 }
+
+stub_classic_libraries_success = {
+    'count': '2',
+    'libraries': [
+        {
+            'desc': 'Description',
+            'entries': [
+                {
+                    'bibcode': '2015MNRAS.446.4239E'
+                },
+                {
+                    'bibcode': '2015A&C....10...61E'
+                },
+                {
+                    'bibcode': '2014A&A...562A.100E'
+                },
+                {
+                    'bibcode': '2013A&A...556A..23E'
+                }
+            ],
+            'lastmod': '01-Dec-2015',
+            'name': 'Name'
+        }
+    ],
+    'owner': 'Owner',
+    'pubid': 'ID',
+    'status': {
+        'cookie': 'ef9df8ds',
+        'libfile': '/file/on/disk',
+        'query_string': 'cookie=ef9df8ds',
+        'server': 'server',
+        'timestamp': 'Tue Dec  1 11:37:39 2015'
+    },
+    'uid': 'ID'
+}

--- a/classic/tests/unit_tests/stub_response.py
+++ b/classic/tests/unit_tests/stub_response.py
@@ -4,7 +4,7 @@ Mock responses to be used with HTTMock
 
 from httmock import urlmatch
 from stub_data import stub_classic_success, stub_classic_unknown_user, stub_classic_wrong_password, \
-    stub_classic_no_cookie
+    stub_classic_no_cookie, stub_classic_libraries_success
 
 
 @urlmatch(netloc=r'(.*\.)?mirror\.com')
@@ -12,6 +12,14 @@ def ads_classic_200(url, request):
     return {
         'status_code': 200,
         'content': stub_classic_success
+    }
+
+
+@urlmatch(netloc=r'(.*\.)?mirror\.com')
+def ads_classic_libraries_200(url, request):
+    return {
+        'status_code': 200,
+        'content': stub_classic_libraries_success
     }
 
 

--- a/classic/tests/unit_tests/test_webservices.py
+++ b/classic/tests/unit_tests/test_webservices.py
@@ -2,15 +2,21 @@
 Test webservices
 """
 import mock
+import testing.postgresql
 
 from flask.ext.testing import TestCase
 from flask import url_for
 from classic import app
+from classic.models import db, Users
 from classic.http_errors import CLASSIC_AUTH_FAILED, CLASSIC_DATA_MALFORMED, CLASSIC_TIMEOUT, CLASSIC_BAD_MIRROR,\
-    CLASSIC_NO_COOKIE, CLASSIC_UNKNOWN_ERROR, MYADS_TIMEOUT, MYADS_UNKNOWN_ERROR
-from stub_response import ads_classic_200, ads_classic_unknown_user, ads_classic_wrong_password, ads_classic_no_cookie, ads_classic_fail, myads_200, myads_fail
+    CLASSIC_NO_COOKIE, CLASSIC_UNKNOWN_ERROR, MYADS_TIMEOUT, MYADS_UNKNOWN_ERROR, NO_CLASSIC_ACCOUNT
+from stub_response import ads_classic_200, ads_classic_unknown_user, ads_classic_wrong_password, ads_classic_no_cookie,\
+    ads_classic_fail, myads_200, myads_fail, ads_classic_libraries_200
 from httmock import HTTMock
 from requests.exceptions import Timeout
+
+
+USER_ID_KEYWORD = 'X-Adsws-Uid'
 
 
 class TestEndpoints(TestCase):
@@ -202,3 +208,144 @@ class TestEndpoints(TestCase):
         self.assertIn('myads', r.json)
         self.assertIn('message', r.json['myads'])
         self.assertIn('status_code', r.json['myads'])
+
+
+class TestClassicLibrariesEndpoint(TestCase):
+    """
+    Test class for GET end point to acquire libraries
+    """
+    postgresql_url_dict = {
+        'port': 1234,
+        'host': '127.0.0.1',
+        'user': 'postgres',
+        'database': 'test'
+    }
+    postgresql_url = 'postgresql://{user}@{host}:{port}/{database}'\
+        .format(
+            user=postgresql_url_dict['user'],
+            host=postgresql_url_dict['host'],
+            port=postgresql_url_dict['port'],
+            database=postgresql_url_dict['database']
+        )
+
+    def create_app(self):
+        """
+        Create the wsgi application
+        """
+        app_ = app.create_app()
+        app_.config['CLASSIC_LOGGING'] = {}
+        app_.config['SQLALCHEMY_BINDS'] = {}
+        app_.config['ADS_CLASSIC_MIRROR_LIST'] = ['mirror.com']
+        app_.config['SQLALCHEMY_BINDS']['imports'] = TestClassicLibrariesEndpoint.postgresql_url
+
+        return app_
+
+    @classmethod
+    def setUpClass(cls):
+        cls.postgresql = \
+            testing.postgresql.Postgresql(**cls.postgresql_url_dict)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.postgresql.stop()
+
+    def setUp(self):
+        """
+        Set up the database for use
+        """
+        db.create_all()
+
+    def tearDown(self):
+        """
+        Remove/delete the database and the relevant connections
+        """
+        db.session.remove()
+        db.drop_all()
+
+    @mock.patch('classic.views.request')
+    def test_get_libraries_end_point(self, mocked_request):
+        """
+        Test the workflow of successfully retrieving a set of classic libraries
+        """
+        stub_get_libraries = {
+            'libraries': [
+                {
+                    'name': 'Name',
+                    'description': 'Description',
+                    'documents': [
+                        '2015MNRAS.446.4239E', '2015A&C....10...61E', '2014A&A...562A.100E', '2013A&A...556A..23E'
+                    ]
+                }
+            ]
+        }
+
+        # 1. The user is identified via header information
+        # - Generate dummy user in database
+        # - Give the header the correct information
+        headers = {USER_ID_KEYWORD: 10}
+        mocked_request.headers = headers
+        user = Users(absolute_uid=10, classic_cookie='ef9df8ds', classic_mirror='mirror.com')
+        db.session.add(user)
+        db.session.commit()
+
+        # 2. The database is checked to see if the user exists, and the cookie retrieved
+        # 3. The ADS Classic end point is contacted, returning a 200, and the content returned
+        url = url_for('classiclibraries')
+        with HTTMock(ads_classic_libraries_200):
+            r = self.client.get(url)
+        self.assertStatus(r, 200)
+        self.assertEqual(r.json['libraries'], stub_get_libraries['libraries'])
+
+    @mock.patch('classic.views.request')
+    def test_get_libraries_when_the_user_does_not_exist(self, mocked_request):
+        """
+        Test that when a user does not exist within the database, that the libraries end point returns a known error
+        message
+        """
+        headers = {USER_ID_KEYWORD: 10}
+        mocked_request.headers = headers
+
+        url = url_for('classiclibraries')
+        r = self.client.get(url)
+
+        self.assertStatus(r, NO_CLASSIC_ACCOUNT['code'])
+        self.assertEqual(r.json['error'], NO_CLASSIC_ACCOUNT['message'])
+
+    @mock.patch('classic.views.request')
+    @mock.patch('classic.views.requests.get')
+    def test_get_libraries_when_ads_classic_timesout(self, mocked_get, mocked_request):
+        """
+        Test that if ADS Classic times out before finishing the request, that the libraries end point returns a known
+        error
+        """
+        headers = {USER_ID_KEYWORD: 10}
+        mocked_request.headers = headers
+
+        user = Users(absolute_uid=10, classic_cookie='ef9df8ds', classic_mirror='mirror.com')
+        db.session.add(user)
+        db.session.commit()
+
+        mocked_get.side_effect = Timeout
+
+        url = url_for('classiclibraries')
+
+        r = self.client.get(url)
+
+        self.assertStatus(r, CLASSIC_TIMEOUT['code'])
+        self.assertEqual(r.json['error'], CLASSIC_TIMEOUT['message'])
+
+    @mock.patch('classic.views.request')
+    def test_get_libraries_when_ads_classic_returns_non_200(self, mocked_request):
+        headers = {USER_ID_KEYWORD: 10}
+        mocked_request.headers = headers
+
+        user = Users(absolute_uid=10, classic_cookie='ef9df8ds', classic_mirror='mirror.com')
+        db.session.add(user)
+        db.session.commit()
+
+        url = url_for('classiclibraries')
+        with HTTMock(ads_classic_fail):
+            r = self.client.get(url)
+
+        self.assertStatus(r, CLASSIC_UNKNOWN_ERROR['code'])
+        self.assertEqual(r.json['error'], CLASSIC_UNKNOWN_ERROR['message'])

--- a/classic/utils.py
+++ b/classic/utils.py
@@ -1,4 +1,3 @@
-
 """
 Contains useful functions and utilities that are not neccessarily only useful
 for this module. But are also used in differing modules insidide the same

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,10 @@ flask-restful
 Flask-Testing
 flask-discoverer
 flask-consulate==0.1.2
+Flask-SQLAlchemy==2.1
 nose
 coveralls
 requests==2.7.0
 httmock==1.2.3
+testing.postgresql==1.2.1
+psycopg2==2.6.1


### PR DESCRIPTION
This commit includes the get end point for obtaining classic libraries.
A suite of tests have been included with stub data. Only a 200 is expected,
with a specific set of content. Any error messages or other types of responses
are handled in a generic way.

A database to store the cookies has been adopted instead of utilising the
myads data store. There are a few reasons for this, specifically for maintainance
purposes, and you can read more about it in the JIRA ticket.

All tests use testing.postgresql, and hard code the database within the
tests to avoid any issues.

The database test class should be slimlined into a base.py file, and then the
database can be included within the authentication end point.