### PR TITLE
Hotfix/replace myads with database

### DIFF
--- a/classic/config.py
+++ b/classic/config.py
@@ -5,7 +5,6 @@ ADS_CLASSIC_MIRROR_LIST = ['adstrio.cfa.harvard.edu', 'adsnun.cfa.harvard.edu', 
                            'ukads.nottingham.ac.uk', 'ads.iucaa.ernet.in', 'ads.inasan.ru', 'ads.bao.ac.cn',
                            'ads.mao.kiev.ua', 'ads.ari.uni-heidelberg.de', 'ads.arsip.lipi.go.id', 'ads.on.br',
                            'saaoads.chpc.ac.za', 'adsabs.harvard.edu']
-CLASSIC_MYADS_USER_DATA_URL = 'http://api.adsabs.harvard.edu/v1/vault/user-data'
 SQLALCHEMY_BINDS = {'imports': ''}
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/classic/models.py
+++ b/classic/models.py
@@ -19,9 +19,10 @@ class Users(db.Model):
     __tablename__ = 'users'
     id = db.Column(db.Integer, primary_key=True)
     absolute_uid = db.Column(db.Integer, unique=True, nullable=False)
-    classic_mirror = db.Column(db.String(32), nullable=False)
-    classic_cookie = db.Column(db.String(32), nullable=False)
+    classic_email = db.Column(db.String, nullable=False)
+    classic_mirror = db.Column(db.String, nullable=False)
+    classic_cookie = db.Column(db.String, nullable=False)
 
     def __repr__(self):
-        return '<User: id {0}, absolute_uid {1}, classic_cookie "{2}">'\
-            .format(self.id, self.absolute_uid, self.classic_cookie)
+        return '<User: id {0}, absolute_uid {1}, classic_cookie "{2}", classic_email "{3}", classic_mirror "{4}">'\
+            .format(self.id, self.absolute_uid, self.classic_cookie, self.classic_email, self.classic_mirror)


### PR DESCRIPTION
Sections of code in AuthenticateUser were updated to no longer use myads.
The tests were also updated. To full replace the behaviour, another end
point needs to be added that gives back the relevant information that is stored
about the user, to the user.