### PR TITLE
Feature/end point to return the ADS Classic settings

### DIFF
--- a/classic/app.py
+++ b/classic/app.py
@@ -8,7 +8,7 @@ from flask import Flask
 from flask.ext.restful import Api
 from flask.ext.discoverer import Discoverer
 from flask.ext.consulate import Consul, ConsulConnectionError
-from views import AuthenticateUser, ClassicLibraries
+from views import AuthenticateUser, ClassicLibraries, ClassicUser
 from models import db
 
 
@@ -36,6 +36,7 @@ def create_app():
     # Add the end resource end points
     api.add_resource(AuthenticateUser, '/auth', methods=['POST'])
     api.add_resource(ClassicLibraries, '/libraries', methods=['GET'])
+    api.add_resource(ClassicUser, '/user', methods=['GET'])
 
     return app
 

--- a/classic/http_errors.py
+++ b/classic/http_errors.py
@@ -38,13 +38,3 @@ NO_CLASSIC_ACCOUNT = dict(
     message='This user has not setup an ADS Classic account',
     code=400
 )
-
-MYADS_TIMEOUT = dict(
-    message='ADSWS myADS end point timed out before it could respond (> 30s)',
-    code=504
-)
-
-MYADS_UNKNOWN_ERROR = dict(
-    message='An unknown error occured on myADS',
-    code=500
-)


### PR DESCRIPTION
There is now an end point that returns the users email and mirror
settings currently stored to be used with ADS Classic.

This is protected by the user scope.